### PR TITLE
Implemented overload for GetIndexItems

### DIFF
--- a/src/Foundation/Search/code/Helixbase.Foundation.Search.csproj
+++ b/src/Foundation/Search/code/Helixbase.Foundation.Search.csproj
@@ -170,6 +170,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="DI\RegisterContainer.cs" />
+    <Compile Include="Indexes.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Repositories\ISearchRepository.cs" />
     <Compile Include="Repositories\SitecoreSearchRepository.cs" />

--- a/src/Foundation/Search/code/Indexes.cs
+++ b/src/Foundation/Search/code/Indexes.cs
@@ -1,0 +1,8 @@
+﻿namespace Helixbase.Foundation.Search
+{
+    public class Indexes
+    {
+        public const string Master = "sitecore_master_index";
+        public const string Web = "sitecore_web_index";
+    }
+}

--- a/src/Foundation/Search/code/Repositories/ISearchRepository.cs
+++ b/src/Foundation/Search/code/Repositories/ISearchRepository.cs
@@ -7,6 +7,24 @@ namespace Helixbase.Foundation.Search.Repositories
 {
     public interface ISearchRepository
     {
+        /// <summary>
+        /// Searches for items in the default index, "sitecore_web_index", and returns them as the type specified.
+        /// </summary>
+        /// <typeparam name="T">The model with which to return the items.</typeparam>
+        /// <param name="predicate">The predicate of the search.</param>
+        /// <param name="orderBy">The order of the search.</param>
+        /// <param name="amount">The amount of items to return.</param>
+        /// <returns>Return an enumerable of items of the type specified.</returns>
+        IEnumerable<T> GetIndexItems<T>(Expression<Func<T, bool>> predicate, Expression<Func<T, object>> orderBy = null, int? amount = null) where T : SearchResultItem;
+
+        /// <summary>
+        /// Searches for items in the provided index and returns them as the type specified.
+        /// </summary>
+        /// <typeparam name="T">The model with which to return the items.</typeparam>
+        /// <param name="predicate">The predicate of the search.</param>
+        /// <param name="orderBy">The order of the search.</param>
+        /// <param name="amount">The amount of items to return.</param>
+        /// <returns>Return an enumerable of items of the type specified.</returns>
         IEnumerable<T> GetIndexItems<T>(string indexName, Expression<Func<T, bool>> predicate, Expression<Func<T, object>> orderBy = null, int? amount = null) where T : SearchResultItem;
     }
 }

--- a/src/Foundation/Search/code/Repositories/SitecoreSearchRepository.cs
+++ b/src/Foundation/Search/code/Repositories/SitecoreSearchRepository.cs
@@ -13,6 +13,11 @@ namespace Helixbase.Foundation.Search.Repositories
     /// </summary>
     public class SitecoreSearchRepository : ISearchRepository
     {
+        public IEnumerable<T> GetIndexItems<T>(Expression<Func<T, bool>> predicate, Expression<Func<T, object>> orderBy = null, int? amount = null) where T : SearchResultItem
+        {
+            return GetIndexItems<T>(Indexes.Web, predicate, orderBy, amount);
+        }
+
         public IEnumerable<T> GetIndexItems<T>(string indexName, Expression<Func<T, bool>> predicate, Expression<Func<T, object>> orderBy = null, int? amount = null) where T : SearchResultItem
         {
             var index = ContentSearchManager.GetIndex(indexName);


### PR DESCRIPTION
Overload has no string for index name to utilise. Instead it is defaulted to sitecore_web_index which is now stored in a constant.