### PR TITLE
Resolve non-singleton dependencies via service location

### DIFF
--- a/src/Feature/Redirects/code/Pipelines/RedirectResolver.cs
+++ b/src/Feature/Redirects/code/Pipelines/RedirectResolver.cs
@@ -12,13 +12,13 @@ namespace Helixbase.Feature.Redirects.Pipelines
 {
     public class RedirectResolver : HttpRequestProcessor
     {
-        private readonly IContextRepository _contextRepository;
-        private readonly IContentRepository _contentRepository;
+        private readonly Func<IContextRepository> _contextRepositoryThunk;
+        private readonly Func<IContentRepository> _contentRepositoryThunk;
 
-        public RedirectResolver(IContextRepository contextRepository, IContentRepository contentRepository)
+        public RedirectResolver(Func<IContextRepository> contextRepositoryThunk, Func<IContentRepository> contentRepositoryThunk)
         {
-            _contextRepository = contextRepository;
-            _contentRepository = contentRepository;
+            _contextRepositoryThunk = contextRepositoryThunk ?? throw new ArgumentNullException(nameof(contextRepositoryThunk));
+            _contentRepositoryThunk = contentRepositoryThunk ?? throw new ArgumentNullException(nameof(contentRepositoryThunk));
         }
 
         public override void Process(HttpRequestArgs args)
@@ -36,9 +36,9 @@ namespace Helixbase.Feature.Redirects.Pipelines
 
         private void Perform301Redirect()
         {
-            var redirectFolder = _contentRepository.GetItem<IRedirectFolder>(new GetItemByQueryOptions
+            var redirectFolder = _contentRepositoryThunk().GetItem<IRedirectFolder>(new GetItemByQueryOptions
             {
-                Query = new Query($"{_contextRepository.GetContextSiteRoot()}/*[@@templateid='{Templates.GlobalFolder.TemplateId.ToString("B").ToUpper()}']/*[@@templateid='{Templates.RedirectFolder.TemplateId.ToString("B").ToUpper()}']")
+                Query = new Query($"{_contextRepositoryThunk().GetContextSiteRoot()}/*[@@templateid='{Templates.GlobalFolder.TemplateId.ToString("B").ToUpper()}']/*[@@templateid='{Templates.RedirectFolder.TemplateId.ToString("B").ToUpper()}']")
             });
 
             // Could also use a builder:


### PR DESCRIPTION
Hi,

We recently came across this issue in our project that's built on Helixbase.  Sitecore pipeline processors are always created as singletons so any dependencies injected into the constructor are retained for the lifetime of the app pool. This is a problem for the content & context repository as they depend on the IRequestContext which should have scoped lifetime.

The immediate upshot of this is that the RedirectResolver is always run in the context of the database that was resolved in the first request to sitecore. e.g. if the first request is to /sitecore then the context database is permanently core.

This post by Corey Smith explains the problem in more detail and suggests a solution.
https://www.coreysmith.co/sitecore-dependency-injection-scoped-services/

I've implemented the suggested solution in this patch.