### PR TITLE
AppVeyor manifest for installing Sitecore and deploying the solution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@
 [Rr]eleases/
 [Xx]64/
 [Xx]86/
-[Bb]uild/
 bld/
 [Bb]in/
 [Oo]bj/

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Azure DevOps:
 AppVeyor:
 
 * An example [appveyor.xml](https://github.com/muso31/Helixbase/blob/master/appveyor.yml) is included which builds, tests, and packages the solution.
+* An example [appveyor-deploy-local.xml](https://github.com/muso31/Helixbase/blob/master/appveyor-deploy-local.yml) is included which installs Sitecore, deploys the WDP package and executes a Unicorn sync.
 
 ## Legacy Versions
 Legacy versions of Helix Base which are no longer updated or maintained can be found below:

--- a/appveyor-deploy-local.yml
+++ b/appveyor-deploy-local.yml
@@ -1,0 +1,49 @@
+version: 0.0.{build}
+skip_branch_with_pr: true
+image: Visual Studio 2017
+services:
+- iis
+- mssql2017
+install:
+- ps: >-
+     Install-Module ParTech.SimpleInstallScripts -RequiredVersion "0.0.89" -Force -SkipPublisherCheck -AllowClobber
+before_build:
+- ps: >-
+     Start-FileDownload 'https://ci.appveyor.com/api/projects/steviemcg/helixbase/artifacts/artifacts%2fHelixbase.Website.zip' wdp.zip
+build_script :
+- ps: >-
+    Install-Sitecore92 -Prefix "helixbase" `
+            -Parameters @{SitecoreSiteName="helixbase.sc.dev.local"} `
+            -DownloadBase $Env:DownloadBase `
+            -SitecoreVersion "920XP0" `
+            -DoInstallPrerequisites `
+            -DoRebuildLinkDatabases:$false `
+            -DoRebuildSearchIndexes:$false `
+            -DoDeployMarketingDefinitions:$false `
+            -SQLServer . `
+            -SqlAdminUser sa `
+            -SqlAdminPassword 'Password12!'
+after_build:
+- ps: >-
+    & "C:\Program Files\IIS\Microsoft Web Deploy V3\msdeploy.exe" `
+            -verb:sync -source:package=wdp.zip `
+            -dest:auto,includeAcls=`"False`" `
+            -enableRule:DoNotDeleteRule `
+            -disableLink:AppPoolExtension `
+            -disableLink:ContentExtension `
+            -disableLink:CertificateExtension `
+            -setParam:name=`"IIS Web Application Name`",value=`"helixbase.sc.dev.local`"
+
+    Import-Module .\build\functions.psm1
+
+    $UnicornSecret = -join ((48..57) + (97..122) | Get-Random -Count 64 | ForEach-Object {[char]$_})
+    
+    $WebRootPath = "c:\inetpub\wwwroot\helixbase.sc.dev.local"
+    
+    Set-SourceFolder ".\build\SourceFolder.config" $WebRootPath "$WebRootPath\App_Data\unicorn"
+    
+    Set-Unicorn-Shared-Secret ".\build\Unicorn.SharedSecret.config" $WebRootPath $UnicornSecret
+    
+    Sync-Unicorn -ControlPanelUrl "http://helixbase.sc.dev.local/unicorn.aspx" -SharedSecret $UnicornSecret
+test_script:
+- ps: 'Test-Site "http://helixbase.sc.dev.local"'

--- a/build/SourceFolder.config
+++ b/build/SourceFolder.config
@@ -1,0 +1,5 @@
+<configuration xmlns:patch="http://www.sitecore.net/xmlconfig/" xmlns:role="http://www.sitecore.net/xmlconfig/role/">
+  <sitecore role:require="Standalone or ContentManagement">
+    <sc.variable name="sourceFolder" value="#sourceFolder#" />
+  </sitecore>
+</configuration>

--- a/build/Unicorn.SharedSecret.config
+++ b/build/Unicorn.SharedSecret.config
@@ -1,0 +1,10 @@
+<configuration xmlns:patch="http://www.sitecore.net/xmlconfig/">
+	<sitecore>
+		<unicorn>
+			<authenticationProvider>
+				<SharedSecret>#SECRET#</SharedSecret>
+				<WriteAuthFailuresToLog>false</WriteAuthFailuresToLog>
+			</authenticationProvider>
+		</unicorn>
+	</sitecore>
+</configuration>

--- a/build/functions.psm1
+++ b/build/functions.psm1
@@ -1,0 +1,38 @@
+Function Set-PublishUrl {
+    param(
+        [Parameter(Mandatory)][string] $configPath, 
+        [Parameter(Mandatory)][string] $publishUrl
+    )
+    
+    [xml]$config = Get-Content $configPath
+    $config.Project.PropertyGroup.PublishUrl = $publishUrl
+    $config.Save($configPath)  
+}
+
+Function Set-SourceFolder {
+    param(
+        [Parameter(Mandatory)][string] $configPath,
+        [Parameter(Mandatory)][string] $websitePath,
+        [Parameter(Mandatory)][string] $sourceFolder
+    )
+    
+    [xml]$config = Get-Content $configPath
+    $config.configuration.sitecore.SelectSingleNode("*").value = $sourceFolder
+
+    $targetPath = [IO.Path]::Combine($websitePath, "App_Config", "Environment", "SourceFolder.config")
+    $config.Save($targetPath)
+}
+
+Function Set-Unicorn-Shared-Secret {
+    param(
+        [Parameter(Mandatory)][string] $configPath,
+        [Parameter(Mandatory)][string] $websitePath,
+        [Parameter(Mandatory)][string] $sharedSecret
+    )
+    
+    [xml]$config = Get-Content $configPath
+    $config.configuration.sitecore.unicorn.authenticationProvider.SharedSecret = $sharedSecret
+
+    $targetPath = [IO.Path]::Combine($websitePath, "App_Config", "Environment", "Unicorn.SharedSecret.config")
+    $config.Save($targetPath)
+}


### PR DESCRIPTION
Hi @richardszalay , could I have your feedback on this one?
I've tried to cut everything down and put some scripts into the appveyor-deploy-local.yml itself

An example build is here: https://ci.appveyor.com/project/steviemcg/helixbase-dbj5l/builds/26149151 which:
- Installs Sitecore
- Deploys the WDP artifact of the latest successful build
- Runs a Unicorn sync
- Pings the site to make sure it's a status 200. (Ready for more functional testing later).

Room for improvement?
- There are still a couple of powershell functions lying around in `build/`
- There's still a hard link to a PowerShell library, *ParTech.SimpleInstallScripts*, which does all the heavy lifting of installing Sitecore for this kind of scenario. I'm not really sure how to avoid this without the yml script getting super heavy. And of course, I'd like to promote ParTech.SimpleInstallScripts as something people might want to use?
- I could move the .psm1 functions to the ParTech.SimpleInstallScripts module, or... I could move everything under `build/examples` as you previously suggested.

I'm going to work a bit more now on trying to do the equivalent of this in Azure Devops, but I'm not sure how much Azure let me modify the build agent VMs like you can on AppVeyor.