### PR TITLE
Added ReferenceCopAnalyzer and a set of rules

### DIFF
--- a/Helixbase.sln
+++ b/Helixbase.sln
@@ -37,6 +37,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Configuration", "Configurat
 	ProjectSection(SolutionItems) = preProject
 		.gitattributes = .gitattributes
 		.gitignore = .gitignore
+		rules\.refrules = rules\.refrules
 		NuGet.config = NuGet.config
 		README.md = README.md
 		sitecore.json = sitecore.json

--- a/rules/.refrules
+++ b/rules/.refrules
@@ -1,0 +1,58 @@
+# This file describes the references that are allowed between different modules (in the context of Helix: https://helix.sitecore.com/principles/architecture-principles/modules.html)
+# More info about the intended use: https://github.com/hermanussen/ReferenceCopAnalyzer
+# Every Visual Studio project should have the following for this to work properly:
+# 1. A package reference to ReferenceCopAnalyzer
+# 2. A reference to this file: <AdditionalFiles Include="$(SolutionDir)\rules\.refrules" />
+
+# Dependencies flow from project to feature to foundation
+[ca].Project.* [ca].Feature.*
+[ca].Feature.* [ca].Foundation.*
+
+# Foundation projects are allowed to reference each other
+[ca].Foundation.* [ca].Foundation.*
+
+# Controllers are allowed to reference various things within the same module
+[ca].Feature.[f].Controllers [ca].Feature.[f].Models
+[ca].Feature.[f].Controllers [ca].Feature.[f].Mediators
+[ca].Feature.[f].Controllers [ca].Feature.[f].Factories
+[ca].Feature.[f].Controllers [ca].Feature.[f].Services
+
+# DI is allowed to reference everything within the same module
+[ca].Feature.[f].DI [ca].Feature.[f].*
+
+# Factories are allowed to deal with models and viewmodels within the same module
+[ca].Feature.[f].Factories [ca].Feature.[f].Models
+[ca].Feature.[f].Factories [ca].Feature.[f].ViewModels
+
+# Mediators deal with factories, services and viewmodels
+[ca].Feature.[f].Mediators [ca].Feature.[f].Factories
+[ca].Feature.[f].Mediators [ca].Feature.[f].Services
+[ca].Feature.[f].Mediators [ca].Feature.[f].ViewModels
+
+# ORM and services are allowed to deal with models, but should perhaps get more freedom to call into other things
+[ca].Feature.[f].Services [ca].Feature.[f].Models
+[ca].Feature.[f].ORM [ca].Feature.[f].Models
+
+# Commands and pipelines can reference anything deeper than their own namespace
+[ca].Feature.[f].Commands.* [ca].Feature.[f].Commands.*
+[ca].Feature.[f].Pipelines.* [ca].Feature.[f].Commands.*
+
+# These things are so widely used and not relevant for checking that we can allow references to them from everywhere
+* Microsoft.Extensions.DependencyInjection
+* System
+* System.*
+* Sitecore
+* Sitecore.*
+* Glass.Mapper
+* Glass.Mapper.*
+
+# Unit tests should only reference modules that their name implies they refer to
+[ca].Foundation.[f].Tests.* [ca].Foundation.[f].*
+[ca].Feature.[f].Tests.* [ca].Feature.[f].*
+[ca].Project.[f].Tests.* [ca].Project.[f].*
+
+# Tests can make use of some test related libraries
+*.Tests.* FluentAssertions
+*.Tests.* Ploeh.AutoFixture
+*.Tests.* NSubstitute
+*.Tests.* Microsoft.VisualStudio.TestTools.UnitTesting

--- a/src/Feature/Hero/Tests/Helixbase.Feature.Hero.Tests.csproj
+++ b/src/Feature/Hero/Tests/Helixbase.Feature.Hero.Tests.csproj
@@ -5,6 +5,9 @@
     <Company>Ethisys Ltd</Company>
   </PropertyGroup>
   <ItemGroup>
+    <AdditionalFiles Include="$(SolutionDir)\rules\.refrules" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="AutoFixture" Version="3.51.0" />
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
     <PackageReference Include="Glass.Mapper.Sc.101.Core" Version="5.8.177" />
@@ -12,6 +15,7 @@
     <PackageReference Include="MSTest.TestAdapter" Version="1.2.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.2.0" />
     <PackageReference Include="NSubstitute" Version="2.0.3" />
+    <PackageReference Include="ReferenceCopAnalyzer" Version="0.2.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Foundation\Core\website\Helixbase.Foundation.Core.csproj" />

--- a/src/Feature/Hero/website/Helixbase.Feature.Hero.csproj
+++ b/src/Feature/Hero/website/Helixbase.Feature.Hero.csproj
@@ -13,6 +13,9 @@
     <ProjectCapability Include="SupportsSystemWeb" />
   </ItemGroup>
   <ItemGroup>
+    <AdditionalFiles Include="$(SolutionDir)\rules\.refrules" />
+  </ItemGroup>
+  <ItemGroup>
     <Content Remove="Views\web.config" />
     <Content Remove="Web.config" />
     <Content Remove="Web.Debug.config" />
@@ -52,6 +55,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="ReferenceCopAnalyzer" Version="0.2.0" />
     <PackageReference Include="Sitecore.ContentSearch.Linq" Version="10.1.0" />
     <PackageReference Include="Sitecore.Kernel" Version="10.1.0" />
     <PackageReference Include="Sitecore.Mvc" Version="10.1.0" />

--- a/src/Feature/ItemUnlock/website/Helixbase.Feature.ItemUnlock.csproj
+++ b/src/Feature/ItemUnlock/website/Helixbase.Feature.ItemUnlock.csproj
@@ -8,6 +8,9 @@
 	<Company>Ethisys Ltd</Company>
   </PropertyGroup>
   <ItemGroup>
+    <AdditionalFiles Include="$(SolutionDir)\rules\.refrules" />
+  </ItemGroup>
+  <ItemGroup>
     <Content Remove="Web.config" />
     <Content Remove="Web.Debug.config" />
     <Content Remove="Web.Release.config" />
@@ -29,6 +32,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" Version="2.0.1" />
+    <PackageReference Include="ReferenceCopAnalyzer" Version="0.2.0" />
     <PackageReference Include="Sitecore.Kernel" Version="10.1.0" />
   </ItemGroup>
 </Project>

--- a/src/Feature/ShowTitles/website/Helixbase.Feature.ShowTitles.csproj
+++ b/src/Feature/ShowTitles/website/Helixbase.Feature.ShowTitles.csproj
@@ -8,6 +8,9 @@
 	<Company>Ethisys Ltd</Company>
   </PropertyGroup>
   <ItemGroup>
+    <AdditionalFiles Include="$(SolutionDir)\rules\.refrules" />
+  </ItemGroup>
+  <ItemGroup>
     <Content Remove="Web.config" />
     <Content Remove="Web.Debug.config" />
     <Content Remove="Web.Release.config" />
@@ -29,6 +32,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" Version="2.0.1" />
+    <PackageReference Include="ReferenceCopAnalyzer" Version="0.2.0" />
     <PackageReference Include="Sitecore.Kernel" Version="10.1.0" />
   </ItemGroup>
 </Project>

--- a/src/Feature/VersionTrim/website/Helixbase.Feature.VersionTrim.csproj
+++ b/src/Feature/VersionTrim/website/Helixbase.Feature.VersionTrim.csproj
@@ -8,6 +8,9 @@
 	<Company>Ehisys Ltd</Company>
   </PropertyGroup>
   <ItemGroup>
+    <AdditionalFiles Include="$(SolutionDir)\rules\.refrules" />
+  </ItemGroup>
+  <ItemGroup>
     <Content Remove="Web.config" />
     <Content Remove="Web.Debug.config" />
     <Content Remove="Web.Release.config" />
@@ -23,6 +26,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" Version="2.0.1" />
+    <PackageReference Include="ReferenceCopAnalyzer" Version="0.2.0" />
     <PackageReference Include="Sitecore.Kernel" Version="10.1.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Foundation/Bootstrap/website/Helixbase.Foundation.Bootstrap.csproj
+++ b/src/Foundation/Bootstrap/website/Helixbase.Foundation.Bootstrap.csproj
@@ -8,6 +8,9 @@
 	<Company>Ethisys Ltd</Company>
   </PropertyGroup>
   <ItemGroup>
+    <AdditionalFiles Include="$(SolutionDir)\rules\.refrules" />
+  </ItemGroup>
+  <ItemGroup>
     <Content Remove="Web.config" />
     <Content Remove="Web.Debug.config" />
     <Content Remove="Web.Release.config" />
@@ -48,6 +51,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" Version="2.0.1" />
+    <PackageReference Include="ReferenceCopAnalyzer" Version="0.2.0" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Scripts\umd\popper-utils.js" />

--- a/src/Foundation/Content/tests/Helixbase.Foundation.Content.Tests.csproj
+++ b/src/Foundation/Content/tests/Helixbase.Foundation.Content.Tests.csproj
@@ -5,6 +5,9 @@
     <Company>Ethisys Ltd</Company>
   </PropertyGroup>
   <ItemGroup>
+    <AdditionalFiles Include="$(SolutionDir)\rules\.refrules" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="AutoFixture" Version="3.51.0" />
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
     <PackageReference Include="Glass.Mapper.Sc.101.Core" Version="5.8.177" />
@@ -12,6 +15,7 @@
     <PackageReference Include="MSTest.TestAdapter" Version="1.2.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.2.0" />
     <PackageReference Include="NSubstitute" Version="2.0.3" />
+    <PackageReference Include="ReferenceCopAnalyzer" Version="0.2.0" />
     <PackageReference Include="Sitecore.Kernel" Version="10.1.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Foundation/Content/website/Helixbase.Foundation.Content.csproj
+++ b/src/Foundation/Content/website/Helixbase.Foundation.Content.csproj
@@ -8,6 +8,9 @@
 	<Company>Ethisys Ltd</Company>
   </PropertyGroup>
   <ItemGroup>
+    <AdditionalFiles Include="$(SolutionDir)\rules\.refrules" />
+  </ItemGroup>
+  <ItemGroup>
     <Content Remove="Web.config" />
     <Content Remove="Web.Debug.config" />
     <Content Remove="Web.Release.config" />
@@ -31,6 +34,7 @@
     <PackageReference Include="Glass.Mapper.Sc.101.Core" Version="5.8.177" />
     <PackageReference Include="Glass.Mapper.Sc.101.Mvc" Version="5.8.177" />
     <PackageReference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" Version="2.0.1" />
+    <PackageReference Include="ReferenceCopAnalyzer" Version="0.2.0" />
     <PackageReference Include="Sitecore.ContentSearch" Version="10.1.0" />
     <PackageReference Include="Sitecore.Kernel" Version="10.1.0" />
   </ItemGroup>

--- a/src/Foundation/Core/website/Helixbase.Foundation.Core.csproj
+++ b/src/Foundation/Core/website/Helixbase.Foundation.Core.csproj
@@ -8,6 +8,9 @@
     <Company>Ethisys Ltd</Company>
   </PropertyGroup>
   <ItemGroup>
+    <AdditionalFiles Include="$(SolutionDir)\rules\.refrules" />
+  </ItemGroup>
+  <ItemGroup>
     <Content Remove="Web.config" />
     <Content Remove="Web.Debug.config" />
     <Content Remove="Web.Release.config" />
@@ -29,6 +32,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" Version="2.0.1" />
+    <PackageReference Include="ReferenceCopAnalyzer" Version="0.2.0" />
     <PackageReference Include="Sitecore.Kernel" Version="10.1.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
   </ItemGroup>

--- a/src/Foundation/DI/website/Helixbase.Foundation.DI.csproj
+++ b/src/Foundation/DI/website/Helixbase.Foundation.DI.csproj
@@ -8,6 +8,9 @@
 	<Company>Ethisys Ltd</Company>
   </PropertyGroup>
   <ItemGroup>
+    <AdditionalFiles Include="$(SolutionDir)\rules\.refrules" />
+  </ItemGroup>
+  <ItemGroup>
     <Content Remove="Web.config" />
     <Content Remove="Web.Debug.config" />
     <Content Remove="Web.Release.config" />
@@ -29,6 +32,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" Version="2.0.1" />
+    <PackageReference Include="ReferenceCopAnalyzer" Version="0.2.0" />
     <PackageReference Include="Sitecore.Kernel" Version="10.1.0" />
     <PackageReference Include="Sitecore.Mvc" Version="10.1.0" />
   </ItemGroup>

--- a/src/Foundation/Logging/website/Helixbase.Foundation.Logging.csproj
+++ b/src/Foundation/Logging/website/Helixbase.Foundation.Logging.csproj
@@ -8,6 +8,9 @@
 	<Company>Ethisys Ltd</Company>
   </PropertyGroup>
   <ItemGroup>
+    <AdditionalFiles Include="$(SolutionDir)\rules\.refrules" />
+  </ItemGroup>
+  <ItemGroup>
     <Content Remove="Web.config" />
     <Content Remove="Web.Debug.config" />
     <Content Remove="Web.Release.config" />
@@ -29,6 +32,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" Version="2.0.1" />
+    <PackageReference Include="ReferenceCopAnalyzer" Version="0.2.0" />
     <PackageReference Include="Sitecore.Kernel" Version="10.1.0" />
   </ItemGroup>
 </Project>

--- a/src/Foundation/ORM/website/Helixbase.Foundation.ORM.csproj
+++ b/src/Foundation/ORM/website/Helixbase.Foundation.ORM.csproj
@@ -8,6 +8,9 @@
 	<Company>Ethisys Ltd</Company>
   </PropertyGroup>
   <ItemGroup>
+    <AdditionalFiles Include="$(SolutionDir)\rules\.refrules" />
+  </ItemGroup>
+  <ItemGroup>
     <Content Remove="Web.config" />
     <Content Remove="Web.Debug.config" />
     <Content Remove="Web.Release.config" />
@@ -36,6 +39,7 @@
   <ItemGroup>
     <PackageReference Include="Glass.Mapper.Sc.101" Version="5.8.177" />
     <PackageReference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" Version="2.0.1" />
+    <PackageReference Include="ReferenceCopAnalyzer" Version="0.2.0" />
     <PackageReference Include="Sitecore.Kernel" Version="10.1.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Foundation/Search/website/Helixbase.Foundation.Search.csproj
+++ b/src/Foundation/Search/website/Helixbase.Foundation.Search.csproj
@@ -8,6 +8,9 @@
 	<Company>Ethisys Ltd</Company>
   </PropertyGroup>
   <ItemGroup>
+    <AdditionalFiles Include="$(SolutionDir)\rules\.refrules" />
+  </ItemGroup>
+  <ItemGroup>
     <Content Remove="Web.config" />
     <Content Remove="Web.Debug.config" />
     <Content Remove="Web.Release.config" />
@@ -29,6 +32,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" Version="2.0.1" />
+    <PackageReference Include="ReferenceCopAnalyzer" Version="0.2.0" />
     <PackageReference Include="Sitecore.ContentSearch" Version="10.1.0" />
     <PackageReference Include="Sitecore.Kernel" Version="10.1.0" />
   </ItemGroup>

--- a/src/Project/Common/website/Helixbase.Project.Common.csproj
+++ b/src/Project/Common/website/Helixbase.Project.Common.csproj
@@ -8,6 +8,9 @@
 	<Company>Ethisys Ltd</Company>
   </PropertyGroup>
   <ItemGroup>
+    <AdditionalFiles Include="$(SolutionDir)\rules\.refrules" />
+  </ItemGroup>
+  <ItemGroup>
     <Content Remove="web.config" />
     <Content Remove="web.Debug.config" />
     <Content Remove="web.Release.config" />
@@ -29,5 +32,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" Version="2.0.1" />
+    <PackageReference Include="ReferenceCopAnalyzer" Version="0.2.0" />
   </ItemGroup>
 </Project>

--- a/src/Project/Helixbase/website/Helixbase.Project.Helixbase.csproj
+++ b/src/Project/Helixbase/website/Helixbase.Project.Helixbase.csproj
@@ -10,6 +10,9 @@
 	<Company>Ethisys Ltd</Company>
   </PropertyGroup>
   <ItemGroup>
+    <AdditionalFiles Include="$(SolutionDir)\rules\.refrules" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectCapability Include="SupportsSystemWeb" />
   </ItemGroup>
   <ItemGroup>
@@ -48,6 +51,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="ReferenceCopAnalyzer" Version="0.2.0" />
     <PackageReference Include="Sitecore.Kernel" Version="10.1.0" />
     <PackageReference Include="Sitecore.Mvc" Version="10.1.0" />
     <PackageReference Include="Sitecore.Mvc.Analytics" Version="10.1.0" />

--- a/src/Website/website/Helixbase.Website.csproj
+++ b/src/Website/website/Helixbase.Website.csproj
@@ -43,6 +43,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <AdditionalFiles Include="$(SolutionDir)\rules\.refrules" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="ReferenceCopAnalyzer">
+      <Version>0.2.0</Version>
+    </PackageReference>
     <PackageReference Include="RichardSzalay.Helix.Publishing.WebRoot" Version="1.5.6" />
     <PackageReference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" Version="2.0.1" />
     <PackageReference Include="Sitecore.Assemblies.Platform">


### PR DESCRIPTION
I created a code analyzer that helps with checking dependency rules called [ReferenceCopAnalyzer](https://github.com/hermanussen/ReferenceCopAnalyzer).

It think this can be particularly useful for Helix solutions, as there are clear rules for how dependencies should flow in a Helix solution. I even included an example [here](https://github.com/hermanussen/ReferenceCopAnalyzer#example-configuration-for-a-sitecore-helix-project).

This pull request adds the analyzer to all the projects and has a file that describes all the rules that must be followed. It is sort of "retro-fitted" so the solution builds without any changes. But this way, if someone starts a project based on Helixbase, they have a good starting point.

The readme on ReferenceCopAnalyzer is quite extensive, so I hope you are willing to take some time to see what it's about. Any feedback (including questions or critical notes) would be much appreciated.

I hope you like it, but if not; that's ok!