### PR TITLE
Update Helixbase.Website.csproj

### DIFF
--- a/src/Website/website/Helixbase.Website.csproj
+++ b/src/Website/website/Helixbase.Website.csproj
@@ -43,7 +43,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="RichardSzalay.Helix.Publishing.WebRoot" />
+    <PackageReference Include="RichardSzalay.Helix.Publishing.WebRoot" />
     <PackageReference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" />
     <PackageReference Include="Sitecore.Assemblies.Platform" />
     <PackageReference Include="Sitecore.Kernel" />


### PR DESCRIPTION
I`ve pulled this branch and had to change RichardSzalay.Helix.Publishing.WebRoot tag to PackageReference otherwise, I get error message: 
Projects that use central package version management should not define the version on the PackageReference items but on the PackageVersion items: